### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,6 +8,7 @@
   ],
   "description" : "perl6 port of HTTP::Tinyish",
   "name" : "HTTP::Tinyish",
+  "license" : "Artistic-2.0",
   "perl" : "6.c",
   "provides" : {
     "HTTP::Tinyish" : "lib/HTTP/Tinyish.pm6",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license