### PR TITLE
Add basic GET test to check core functionality

### DIFF
--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -2,6 +2,15 @@ use v6;
 use Test;
 use HTTP::Tinyish;
 
-pass "ok";
+plan 1;
 
-done-testing;
+# Try fetching an url before the time out!
+await Promise.anyof(
+  Promise.start({
+    my $resp = HTTP::Tinyish.new.get("https://github.com/skaji/perl6-HTTP-Tinyish");
+    unless is($resp<status>, 200, 'GET response code') {
+      diag "Unable to reach github. Check your response code, if 599 you may be missing curl.";
+    }
+  }),
+  Promise.in(5).then({ skip-rest "Test timed out!"; exit 1 })
+);


### PR DESCRIPTION
Currently windows systems will blindly install this module despite not having curl.
This causes frustrating issues for upstream for modules who fail due to their reliance on this module.

By running a simple test we should be able to deduce if the module can be installed or not on a system.