### PR TITLE
Fix Build.pm to exit 0 on success

### DIFF
--- a/Build.pm
+++ b/Build.pm
@@ -3,7 +3,7 @@ unit class Build;
 
 method build($dist-path) {
     my $proc = run "curl", "--version", :out, :err;
-    return if $proc.exitcode == 0;
+    return True if $proc.exitcode == 0;
 
     die "This module requires 'curl' command, but couldn't find it, abort.";
 }


### PR DESCRIPTION
Previously zef had a bug where it marked all failed BUILD phase as a pass. Fixing zef revealed that this Build.pm exits 1 because it did not explicitly exit on a true value.