### PR TITLE
Add CPAN5 tag

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -19,7 +19,7 @@
   },
   "resources" : [ ],
   "source-url" : "git://github.com/skaji/perl6-HTTP-Tinyish.git",
-  "tags" : [ ],
+  "tags" : [ "CPAN5" ],
   "test-depends" : [ ],
   "version" : "0.1.1"
 }


### PR DESCRIPTION
As this appears to be a straight port of a Perl 5 module with the same interface, I think it warrants the CPAN5 tag.