### PR TITLE
Support mulitple backends

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -7,7 +7,8 @@
   ],
   "depends": [
     "File::Temp",
-    "curl:from<bin>"
+    "File::Which",
+    "HTTP::Tiny"
   ],
   "description": "Raku port of HTTP::Tinyish",
   "license": "Artistic-2.0",
@@ -17,6 +18,7 @@
     "HTTP::Tinyish": "lib/HTTP/Tinyish.rakumod",
     "HTTP::Tinyish::Base": "lib/HTTP/Tinyish/Base.rakumod",
     "HTTP::Tinyish::Curl": "lib/HTTP/Tinyish/Curl.rakumod",
+    "HTTP::Tinyish::HTTPTiny": "lib/HTTP/Tinyish/HTTPTiny.rakumod",
     "HTTP::Tinyish::FileTempFactory": "lib/HTTP/Tinyish/FileTempFactory.rakumod"
   },
   "resources": [

--- a/lib/HTTP/Tinyish/HTTPTiny.rakumod
+++ b/lib/HTTP/Tinyish/HTTPTiny.rakumod
@@ -1,0 +1,79 @@
+use HTTP::Tinyish::Base;
+
+unit class HTTP::Tinyish::HTTPTiny is HTTP::Tinyish::Base;
+
+my constant DEBUG = %*ENV<HTTP_TINYISH_DEBUG>;
+
+has      $!client;
+has      $.async = False;
+has Int  $.timeout = 60;
+has Int  $.max-redirect = 5;
+has      $.agent = $?PACKAGE.perl;
+has      %.default-headers;
+has Bool $.verify-ssl = True;
+
+submethod TWEAK {
+    ( try require ::('HTTP::Tiny') ) === Nil and return;
+
+    $!client = ::('HTTP::Tiny').new:
+        :%!default-headers,
+        :$!agent,
+        :$!verify-ssl,
+        :$!max-redirect,
+        :$!timeout;
+}
+
+method configure ( --> Hash ) {
+    my %meta;
+
+    ( try require ::('HTTP::Tiny') ) === Nil and return %meta;
+
+    %meta<http>  = True;
+    %meta<https> = so ::('HTTP::Tiny').can-ssl;
+
+    return %meta;
+}
+
+method request ( $method, $url, Bool :$bin = False, *%opts ) {
+    warn "=> { $method, $url, |%opts }" if DEBUG;
+
+    if $.async {
+        my $raw = start $!client.request: $method, $url, |%opts;
+
+        return $raw if $bin;
+
+        return $raw.then: {
+            my $res = .result;
+            $res<content> = ( $res<content> // Blob.new ).decode;
+            $res;
+        }
+    }
+
+    my $res = $!client.request: $method, $url, |%opts;
+
+    $res<content> = ( $res<content> // Blob.new ).decode unless $bin;
+
+    return $res;
+}
+
+method mirror ( $url, $file, Bool :$bin = False, *%opts ) {
+    warn "=> { $url, $file, |%opts }" if DEBUG;
+
+    if $.async {
+        my $raw = start $!client.mirror: $url, $file, |%opts;
+
+        return $raw if $bin;
+
+        return $raw.then: {
+            my $res = .result;
+            $res<content> = ( $res<content> // Blob.new ).decode;
+            $res;
+        }
+    }
+
+    my $res = $!client.mirror: $url, $file, |%opts;
+
+    $res<content> = ( $res<content> // Blob.new ).decode unless $bin;
+
+    return $res;
+}

--- a/xt/01-basic.rakutest
+++ b/xt/01-basic.rakutest
@@ -3,6 +3,8 @@ use HTTP::Tinyish;
 use File::Temp;
 use JSON::Pretty;
 
+my $*HTTP-TINYISH-PREFERRED-BACKEND = $_ with %*ENV<HTTP_TINYISH_PREFERRED_BACKEND>;
+
 my $HTTBIN_HOST = %*ENV<HTTPBIN_HOST> || "httpbin.org";
 my $IS_HTTBIN = $HTTBIN_HOST eq "httpbin.org";
 
@@ -89,8 +91,11 @@ if !$IS_HTTBIN {
     isnt %res<status>, 200; # either 302 or 599
 }
 
-%res = HTTP::Tinyish.new(timeout => 1).get("http://$HTTBIN_HOST/delay/2");
-like %res<status>.Str, rx/^5/;
+{
+    todo 'HTTP::Tiny does not support timeouts' if ( $*HTTP-TINYISH-PREFERRED-BACKEND // '' ).ends-with: 'HTTPTiny';
+    %res = HTTP::Tinyish.new(timeout => 1).get("http://$HTTBIN_HOST/delay/2");
+    like %res<status>.Str, rx/^5/;
+}
 
 %res = HTTP::Tinyish.new.get("http://$HTTBIN_HOST/encoding/utf8");
 like %res<content>, rx/コンニチハ/;

--- a/xt/02-binary.rakutest
+++ b/xt/02-binary.rakutest
@@ -3,6 +3,8 @@ use Test;
 use File::Temp;
 use JSON::Pretty;
 
+my $*HTTP-TINYISH-PREFERRED-BACKEND = $_ with %*ENV<HTTP_TINYISH_PREFERRED_BACKEND>;
+
 my $HTTBIN_HOST = %*ENV<HTTPBIN_HOST> || "httpbin.org";
 
 subtest {

--- a/xt/03-async.rakutest
+++ b/xt/03-async.rakutest
@@ -3,6 +3,8 @@ use HTTP::Tinyish;
 use File::Temp;
 use JSON::Pretty;
 
+my $*HTTP-TINYISH-PREFERRED-BACKEND = $_ with %*ENV<HTTP_TINYISH_PREFERRED_BACKEND>;
+
 my $HTTBIN_HOST = %*ENV<HTTPBIN_HOST> || "httpbin.org";
 my $IS_HTTBIN = $HTTBIN_HOST eq "httpbin.org";
 
@@ -84,8 +86,11 @@ if !$IS_HTTBIN {
     isnt %res<status>, 200; # either 302 or 599
 }
 
-%res = await HTTP::Tinyish.new(:async, timeout => 1).get("http://$HTTBIN_HOST/delay/2");
-like %res<status>.Str, rx/^5/;
+{
+    todo 'HTTP::Tiny does not support timeouts' if ( $*HTTP-TINYISH-PREFERRED-BACKEND // '' ).ends-with: 'HTTPTiny';
+    %res = await HTTP::Tinyish.new(:async, timeout => 1).get("http://$HTTBIN_HOST/delay/2");
+    like %res<status>.Str, rx/^5/;
+}
 
 %res = await HTTP::Tinyish.new(:async).get("http://$HTTBIN_HOST/encoding/utf8");
 like %res<content>, rx/コンニチハ/;


### PR DESCRIPTION
This commit adds support for one additional backend based on [HTTP::Tiny](https://raku.land/zef:jjatria/HTTP::Tiny), a minimal HTTP client written in pure Raku. It also adds the mechanism to support more backends as they become available (one based on [Cro::HTTP](https://raku.land/cpan:JNTHN/Cro::HTTP) would seem like the obvious next step).

As part of this change, it also drops the requirement on a curl binary and replaces it by adding a dependency on [File::Which](https://raku.land/github:azawawi/File::Which) (used to determine if curl is installed) and on HTTP::Tiny (used as a the fallback client when curl is not available). As HTTP::Tiny is pure Raku, it is guaranteed to be available wherever we can run HTTP::Tinyish.

It adds a rudimentary mechanism to specify the preferred backend, which is useful for testing, although this might have to be revisited.

The code still prefers to use curl when it is available. Note that this differs from the Perl version, which prefers the pure-Perl [HTTP::Tiny](https://metacpan.org/pod/HTTP::Tiny) to curl if the scheme is supported.

Also note that the Raku [HTTP::Tiny does not currently support timeouts](https://gitlab.com/jjatria/http-tiny/-/issues/4) (those tests had to be marked as TODO when using that backend) because of limitations in IO::Socket::INET and IO::Socket::SSL.

The footprint of this unsolicited change is quite large, so I would not be surprised if you had plenty of comments and opinions about how this is implemented. I'd be happy to hear what you think, and to make any changes you think are warranted.