### PR TITLE
replace deprecated `.perl` call with `.raku`

### DIFF
--- a/lib/HTTP/Tinyish/Curl.rakumod
+++ b/lib/HTTP/Tinyish/Curl.rakumod
@@ -9,7 +9,7 @@ has $.async = False;
 has $.curl = "curl";
 has Int $.timeout = 60;
 has Int $.max-redirect = 5;
-has $.agent = $?PACKAGE.perl;
+has $.agent = $?PACKAGE.raku;
 has %.default-headers;
 has Bool $.verify-ssl = True;
 


### PR DESCRIPTION
When I use this module, with Rakudo™ v2026.03 (MoarVM version 2026.03), I get this warning:

```
Saw 1 occurrence of deprecated code.
================================================================================
Method perl (from Mu) seen at:
  /home/modula/.raku/sources/6ABCB2EE09D60502847095627D45672DE9E303B8 (HTTP::Tinyish::Curl), line 12
Please use raku instead.
--------------------------------------------------------------------------------
Please contact the author to have these occurrences of deprecated code
adapted, so that this message will disappear!
```

This PR makes the recommended change in order to get rid of the warning.